### PR TITLE
Update to GS 9540

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Heroku Buildpack for Ghostscript
 
-Currently installs Ghostscript 9.27 on Heroku.
+Currently installs Ghostscript 9.53.3 on Heroku.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Heroku Buildpack for Ghostscript
 
-Currently installs Ghostscript 9.21 on Heroku Cedar.
+Currently installs Ghostscript 9.23 on Heroku.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Heroku Buildpack for Ghostscript
 
-Currently installs Ghostscript 9.16 on Heroku Cedar.
+Currently installs Ghostscript 9.21 on Heroku Cedar.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Heroku Buildpack for Ghostscript
 
-Currently installs Ghostscript 9.23 on Heroku.
+Currently installs Ghostscript 9.27 on Heroku.
 
 ## Install
 

--- a/bin/compile
+++ b/bin/compile
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir>
 
-echo "-----> Installing Ghostscript 9.27"
+echo "-----> Installing Ghostscript 9.53.3"
 
 BUILD_DIR=$1
-PACKAGE="https://s3.amazonaws.com/tgl.public/buildpacks/ghostscript/ghostscript-9.27-linux-x86_64.tgz"
-BINARY="ghostscript-9.27-linux-x86_64/gs-927-linux-x86_64"
+PACKAGE="https://s3.amazonaws.com/tgl.public/buildpacks/ghostscript/ghostscript-9.53.3-linux-x86_64.tgz"
+BINARY="ghostscript-9.53.3-linux-x86_64/gs-9533-linux-x86_64"
 LOCATION="$BUILD_DIR/vendor/gs/bin"
 
 mkdir -p $LOCATION

--- a/bin/compile
+++ b/bin/compile
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir>
 
-echo "-----> Installing Ghostscript 9.53.3"
+echo "-----> Installing Ghostscript 9.54.0"
 
 BUILD_DIR=$1
-PACKAGE="https://s3.amazonaws.com/tgl.public/buildpacks/ghostscript/ghostscript-9.53.3-linux-x86_64.tgz"
-BINARY="ghostscript-9.53.3-linux-x86_64/gs-9533-linux-x86_64"
+PACKAGE="https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9540/ghostscript-9.54.0-linux-x86_64.tgz"
+BINARY="ghostscript-9.54.0-linux-x86_64/gs-9540-linux-x86_64"
 LOCATION="$BUILD_DIR/vendor/gs/bin"
 
 mkdir -p $LOCATION
-curl $PACKAGE -s -o - | tar xzf - -C $LOCATION
+curl $PACKAGE -L -s -o - | tar xzf - -C $LOCATION
 mv $LOCATION/$BINARY $LOCATION/gs
 
 echo "-----> Building runtime environment for Ghostscript"

--- a/bin/compile
+++ b/bin/compile
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir>
 
-echo "-----> Installing Ghostscript 9.16"
+echo "-----> Installing Ghostscript 9.21"
 
 BUILD_DIR=$1
-PACKAGE="https://s3.amazonaws.com/tgl.public/buildpacks/ghostscript/ghostscript.tgz"
-LOCATION="$BUILD_DIR/vendor/gs"
+PACKAGE="https://s3.amazonaws.com/tgl.public/buildpacks/ghostscript/ghostscript-9.21-linux-x86_64.tgz"
+BINARY="ghostscript-9.21-linux-x86_64/gs-921-linux-x86_64"
+LOCATION="$BUILD_DIR/vendor/gs/bin"
 
 mkdir -p $LOCATION
 curl $PACKAGE -s -o - | tar xzf - -C $LOCATION
+mv $LOCATION/$BINARY $LOCATION/gs
 
 echo "-----> Building runtime environment for Ghostscript"
 

--- a/bin/compile
+++ b/bin/compile
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir>
 
-echo "-----> Installing Ghostscript 9.23"
+echo "-----> Installing Ghostscript 9.27"
 
 BUILD_DIR=$1
-PACKAGE="https://s3.amazonaws.com/tgl.public/buildpacks/ghostscript/ghostscript-9.23-linux-x86_64.tgz"
-BINARY="ghostscript-9.23-linux-x86_64/gs-923-linux-x86_64"
+PACKAGE="https://s3.amazonaws.com/tgl.public/buildpacks/ghostscript/ghostscript-9.27-linux-x86_64.tgz"
+BINARY="ghostscript-9.27-linux-x86_64/gs-927-linux-x86_64"
 LOCATION="$BUILD_DIR/vendor/gs/bin"
 
 mkdir -p $LOCATION

--- a/bin/compile
+++ b/bin/compile
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir>
 
-echo "-----> Installing Ghostscript 9.21"
+echo "-----> Installing Ghostscript 9.23"
 
 BUILD_DIR=$1
-PACKAGE="https://s3.amazonaws.com/tgl.public/buildpacks/ghostscript/ghostscript-9.21-linux-x86_64.tgz"
-BINARY="ghostscript-9.21-linux-x86_64/gs-921-linux-x86_64"
+PACKAGE="https://s3.amazonaws.com/tgl.public/buildpacks/ghostscript/ghostscript-9.23-linux-x86_64.tgz"
+BINARY="ghostscript-9.23-linux-x86_64/gs-923-linux-x86_64"
 LOCATION="$BUILD_DIR/vendor/gs/bin"
 
 mkdir -p $LOCATION

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-echo "Ghostscript 9.27"
+echo "Ghostscript 9.53.3"
 exit 0
 

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-echo "Ghostscript 9.21"
+echo "Ghostscript 9.23"
 exit 0
 

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-echo "Ghostscript 9.53.3"
+echo "Ghostscript 9.54.0"
 exit 0
 

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-echo "Ghostscript 9.16"
+echo "Ghostscript 9.21"
 exit 0
 

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-echo "Ghostscript 9.23"
+echo "Ghostscript 9.27"
 exit 0
 


### PR DESCRIPTION
Update to GhostScript 9.54.0

Release from 9.55  and above use a new Postscript interpreter which is not compatible.
Integration in our code base need more works.